### PR TITLE
Allow use functions from PartSegCore-compiled-backend as numba alternative for data to texture mapping 

### DIFF
--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -573,7 +573,7 @@ def test_contour(input_data, expected_data_view):
     np.testing.assert_array_equal(layer.data, input_data)
 
     np.testing.assert_array_equal(
-        layer._raw_to_displayed(input_data.astype(np.float32)),
+        layer._raw_to_displayed(input_data),
         layer._data_view,
     )
     data_view_before_contour = layer._data_view.copy()

--- a/src/napari/settings/_experimental.py
+++ b/src/napari/settings/_experimental.py
@@ -2,11 +2,15 @@ from typing import Any
 
 from napari._pydantic_compat import Field
 from napari.settings._base import EventedSettings
+from napari.utils.colormap_backend import (
+    ColormapBackend,
+    set_backend as set_colormap_backend,
+)
 from napari.utils.events import Event
 from napari.utils.translations import trans
 from napari.utils.triangulation_backend import (
     TriangulationBackend,
-    set_backend,
+    set_backend as set_triangulation_backend,
 )
 
 
@@ -20,6 +24,8 @@ class ExperimentalSettings(EventedSettings):
             _update_triangulation_backend
         )
         self.events.triangulation_backend(value=self.triangulation_backend)
+        self.events.colormap_backend.connect(_update_colormap_backend)
+        self.events.colormap_backend(value=self.colormap_backend)
 
     async_: bool = Field(
         False,
@@ -89,6 +95,18 @@ class ExperimentalSettings(EventedSettings):
         ),
         env='napari_triangulation_backend',
     )
+    colormap_backend: ColormapBackend = Field(
+        ColormapBackend.fastest_available,
+        title=trans._('Colormap backend to use for Labels layer'),
+        description=trans._(
+            'Color mapping backend to use for Labels layer.\n'
+            "'partsegcore' requires the optional 'partsegcore-compiled-backend' package.\n"
+            "'numba' requires the optional 'numba' package.\n"
+            "'pure python' uses only NumPy and Python.\n"
+            "The 'fastest available' backend will select the fastest installed backend.\n"
+        ),
+        env='napari_colormap_backend',
+    )
 
     compiled_triangulation: bool = Field(
         default=False,
@@ -107,4 +125,10 @@ class ExperimentalSettings(EventedSettings):
 def _update_triangulation_backend(event: Event) -> None:
     experimental: ExperimentalSettings = event.source
 
-    set_backend(experimental.triangulation_backend)
+    set_triangulation_backend(experimental.triangulation_backend)
+
+
+def _update_colormap_backend(event: Event) -> None:
+    experimental: ExperimentalSettings = event.source
+
+    set_colormap_backend(experimental.colormap_backend)

--- a/src/napari/utils/colormap_backend.py
+++ b/src/napari/utils/colormap_backend.py
@@ -1,0 +1,64 @@
+from napari.utils.compat import StrEnum
+
+
+class ColormapBackend(StrEnum):
+    """
+    Enum for colormap backends.
+
+    Attributes
+    ----------
+    numba : ColormapBackend
+        Use Numba for colormap operations.
+    pure_python : ColormapBackend
+        Use pure Python for colormap operations.
+    fastest_available : ColormapBackend
+        Use the fastest available backend, which may be Numba or a compiled backend.
+    """
+
+    fastest_available = 'Fastest available'
+    pure_python = 'Pure Python'
+    numba = 'numba'
+    partsegcore = 'PartSegCore'
+
+    def __str__(self) -> str:
+        """Return the string representation of the backend."""
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        """Return the string representation of the backend."""
+        return self.name
+
+    @classmethod
+    def _missing_(cls, value: object) -> 'ColormapBackend':
+        """Handle missing values in the enum."""
+        # Handle the case where the value is not a valid enum member
+        if isinstance(value, str):
+            return cls[value.replace(' ', '_').lower()]
+        raise ValueError(f"'{value}' is not a valid ColormapBackend.")
+
+
+def get_backend() -> ColormapBackend:
+    from napari.utils.colormaps import _accelerated_cmap
+
+    return _accelerated_cmap.COLORMAP_BACKEND
+
+
+def set_backend(backend: ColormapBackend) -> ColormapBackend:
+    """Set the colormap backend to use.
+
+    Parameters
+    ----------
+    backend : ColormapBackend
+        The colormap backend to use.
+
+    Returns
+    -------
+    ColormapBackend
+        The previous colormap backend.
+    """
+    from napari.utils.colormaps import _accelerated_cmap
+
+    previous_backend = _accelerated_cmap.COLORMAP_BACKEND
+    _accelerated_cmap.set_colormap_backend(backend)
+
+    return previous_backend

--- a/src/napari/utils/colormaps/_tests/test_colormap.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap.py
@@ -9,10 +9,11 @@ import pytest
 
 from napari._pydantic_compat import ValidationError
 from napari.utils.color import ColorArray
-from napari.utils.colormaps import Colormap, _accelerated_cmap, colormap
-from napari.utils.colormaps._accelerated_cmap import (
-    MAPPING_OF_UNKNOWN_VALUE,
-    _labels_raw_to_texture_direct_numpy,
+from napari.utils.colormap_backend import ColormapBackend, set_backend
+from napari.utils.colormaps import (
+    Colormap,
+    _accelerated_cmap,
+    colormap,
 )
 from napari.utils.colormaps.colormap import (
     CyclicLabelColormap,
@@ -21,6 +22,22 @@ from napari.utils.colormaps.colormap import (
     _normalize_label_colormap,
 )
 from napari.utils.colormaps.colormap_utils import label_colormap
+
+backends = [ColormapBackend.pure_python]
+if _accelerated_cmap.numba is not None:
+    backends.append(ColormapBackend.numba)
+if _accelerated_cmap.partsegcore_mapping is not None:
+    backends.append(ColormapBackend.partsegcore)
+
+
+@pytest.fixture(autouse=True, params=backends)
+def colormap_backend(request):
+    """Fixture to set the colormap backend for each test."""
+    backend = request.param
+    set_backend(backend)
+    yield backend
+    # Reset the backend after the test
+    set_backend(ColormapBackend.fastest_available)
 
 
 def test_linear_colormap():
@@ -156,6 +173,7 @@ def _disable_jit(monkeypatch):
     no class definitions, only functions.
     """
     pytest.importorskip('numba')
+
     with patch('numba.core.config.DISABLE_JIT', True):
         importlib.reload(_accelerated_cmap)
         yield
@@ -204,7 +222,7 @@ def test_direct_label_colormap_simple(direct_label_colormap):
 
     assert len(label_mapping) == 6
     assert len(color_dict) == 5
-    assert label_mapping[None] == MAPPING_OF_UNKNOWN_VALUE
+    assert label_mapping[None] == _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE
     assert label_mapping[12] == label_mapping[3]
     np.testing.assert_array_equal(
         color_dict[label_mapping[0]], direct_label_colormap.color_dict[0]
@@ -250,17 +268,17 @@ def test_cast_direct_labels_to_minimum_type(direct_label_colormap):
                 label_mapping[1],
                 label_mapping[2],
                 label_mapping[3],
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
                 label_mapping[3],
-                MAPPING_OF_UNKNOWN_VALUE,
-                MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
+                _accelerated_cmap.MAPPING_OF_UNKNOWN_VALUE,
             ]
         ),
     )
@@ -291,11 +309,22 @@ def test_test_cast_direct_labels_to_minimum_type_no_jit(num, dtype):
     assert cast.dtype == dtype
 
 
-def test_zero_preserving_modulo_naive():
+def test_zero_preserving_modulo_naive_vs_numba():
     pytest.importorskip('numba')
+
     data = np.arange(1000, dtype=np.uint32)
     res1 = _accelerated_cmap.zero_preserving_modulo_numpy(data, 49, np.uint8)
     res2 = _accelerated_cmap.zero_preserving_modulo(data, 49, np.uint8)
+    npt.assert_array_equal(res1, res2)
+
+
+def test_zero_preserving_modulo_naive_vs_partseg():
+    pytest.importorskip('PartSegCore_compiled_backend.napari_mapping')
+    data = np.arange(1000, dtype=np.uint32)
+    res1 = _accelerated_cmap.zero_preserving_modulo_numpy(data, 49, np.uint8)
+    res2 = _accelerated_cmap.zero_preserving_modulo_partsegcore(
+        data, 49, np.uint8
+    )
     npt.assert_array_equal(res1, res2)
 
 
@@ -514,7 +543,7 @@ def test_direct_colormap_negative_values_numpy():
     }
     cmap = DirectLabelColormap(color_dict=color_dict)
 
-    res = _labels_raw_to_texture_direct_numpy(
+    res = _accelerated_cmap._labels_raw_to_texture_direct_numpy(
         np.array([-1, -2, 5], dtype=np.int8), cmap
     )
     npt.assert_array_equal(res, [1, 2, 0])
@@ -522,7 +551,7 @@ def test_direct_colormap_negative_values_numpy():
     cmap.selection = -2
     cmap.use_selection = True
 
-    res = _labels_raw_to_texture_direct_numpy(
+    res = _accelerated_cmap._labels_raw_to_texture_direct_numpy(
         np.array([-1, -2, 5], dtype=np.int8), cmap
     )
     npt.assert_array_equal(res, [0, 1, 0])

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -28,6 +28,14 @@ if TYPE_CHECKING:
     from numba import typed
 
 
+__all__ = (
+    'Colormap',
+    'ColormapInterpolationMode',
+    'CyclicLabelColormap',
+    'DirectLabelColormap',
+)
+
+
 class ColormapInterpolationMode(StrEnum):
     """INTERPOLATION: Interpolation mode for colormaps.
 

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -16,7 +16,7 @@ from vispy.color import (
 )
 from vispy.color.colormap import LUT_len
 
-from napari.utils.colormaps._accelerated_cmap import minimum_dtype_for_labels
+from napari.utils.colormaps import _accelerated_cmap
 from napari.utils.colormaps.bop_colors import bopd
 from napari.utils.colormaps.colormap import (
     Colormap,
@@ -588,7 +588,7 @@ def shuffle_and_extend_colormap(
     """
     rng = np.random.default_rng(seed)
     n_colors_prev = len(colormap.colors)
-    dtype = minimum_dtype_for_labels(n_colors_prev)
+    dtype = _accelerated_cmap.minimum_dtype_for_labels(n_colors_prev)
     indices = np.arange(n_colors_prev)
     rng.shuffle(indices)
     shuffled_colors = colormap.colors[indices]


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/6617

# References and relevant issues

A way to fix warm up time reported here: https://github.com/napari/napari/issues/3852#issuecomment-1905248322

# Description

This PR adds `PartSegCore-compiled-backend` as an alternative backend to numba for fast mapping from raw data to texture. 

Instead of depending on jited function, that have compilation delay it uses precompiled code from `PartSegCore-compiled-backend` 

It uses these two functions:

1. [map_array_parallel](https://partsegcore...